### PR TITLE
fixes Error: Cannot find module '.../bcrypt/lib/binding/napi-v3/bcryp…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:21-alpine AS base
+FROM --platform=linux/AMD64 node:21-alpine AS base
 LABEL org.opencontainers.image.source="https://github.com/hoiekim/docmost"
 
-FROM base AS builder
+FROM --platform=linux/AMD64 base AS builder
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ RUN npm install -g pnpm
 RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 
-FROM base AS installer
+FROM --platform=linux/AMD64 base AS installer
 
 RUN apk add --no-cache curl bash
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     },
     "overrides": {
       "jsdom": "25.0.1"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "bcrypt"
+    ]
   }
 }


### PR DESCRIPTION
Fixes error that causes the app to start.

See more in the followings
* https://github.com/kelektiv/node.bcrypt.js/issues/800#issuecomment-2646853557
* https://github.com/pnpm/pnpm/issues/9032