### PR TITLE
implements feature to publish space

### DIFF
--- a/apps/client/src/components/layouts/global/top-menu.tsx
+++ b/apps/client/src/components/layouts/global/top-menu.tsx
@@ -23,7 +23,7 @@ export default function TopMenu() {
   const user = currentUser?.user;
   const workspace = currentUser?.workspace;
 
-  if (!user || !workspace) {
+  if (!user || user.isAnonymous || !workspace) {
     return <></>;
   }
 

--- a/apps/client/src/features/editor/page-editor.tsx
+++ b/apps/client/src/features/editor/page-editor.tsx
@@ -80,6 +80,8 @@ export default function PageEditor({
   }, [pageId, ydoc, data?.token]);
 
   const remoteProvider = useMemo(() => {
+    if (!data?.token) return;
+
     const provider = new HocuspocusProvider({
       name: documentName,
       url: collaborationURL,
@@ -105,6 +107,8 @@ export default function PageEditor({
   }, [ydoc, pageId, data?.token]);
 
   useLayoutEffect(() => {
+    if (!remoteProvider) return;
+    
     remoteProvider.connect();
 
     return () => {
@@ -117,7 +121,7 @@ export default function PageEditor({
 
   const extensions = [
     ...mainExtensions,
-    ...collabExtensions(remoteProvider, currentUser.user),
+    ...(remoteProvider ? collabExtensions(remoteProvider, currentUser.user) : []),
   ];
 
   const editor = useEditor(

--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -27,6 +27,7 @@ import { PageWidthToggle } from "@/features/user/components/page-width-pref.tsx"
 import { useTranslation } from "react-i18next";
 import ExportModal from "@/components/common/export-modal";
 import { yjsConnectionStatusAtom } from "@/features/editor/atoms/editor-atoms.ts";
+import { userAtom } from "@/features/user/atoms/current-user-atom";
 
 interface PageHeaderMenuProps {
   readOnly?: boolean;
@@ -79,6 +80,7 @@ function PageActionMenu({ readOnly }: PageActionMenuProps) {
   const [tree] = useAtom(treeApiAtom);
   const [exportOpened, { open: openExportModal, close: closeExportModal }] =
     useDisclosure(false);
+  const [user,] = useAtom(userAtom);
 
   const handleCopyLink = () => {
     const pageUrl =
@@ -127,11 +129,13 @@ function PageActionMenu({ readOnly }: PageActionMenuProps) {
           </Menu.Item>
           <Menu.Divider />
 
-          <Menu.Item leftSection={<IconArrowsHorizontal size={16} />}>
-            <Group wrap="nowrap">
-              <PageWidthToggle label={t("Full width")} />
-            </Group>
-          </Menu.Item>
+          {!user.isAnonymous && (
+            <Menu.Item leftSection={<IconArrowsHorizontal size={16} />}>
+              <Group wrap="nowrap">
+                <PageWidthToggle label={t("Full width")} />
+              </Group>
+            </Menu.Item>
+          )}
 
           <Menu.Item
             leftSection={<IconHistory size={16} />}

--- a/apps/client/src/features/space/components/publish-space-button.tsx
+++ b/apps/client/src/features/space/components/publish-space-button.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@mantine/core";
+import React from "react";
+import { usePublishMutation, useSpaceQuery } from "@/features/space/queries/space-query.ts";
+import { useTranslation } from "react-i18next";
+
+interface PublishSpaceButtonProps {
+  spaceId: string;
+}
+
+export default function PublishSpaceButton({ spaceId }: PublishSpaceButtonProps) {
+  const { t } = useTranslation();
+  const { data: space } = useSpaceQuery(spaceId);
+  const publishSpaceMutation = usePublishMutation();
+
+  const buttonLabel = space?.isPublished ? t("Unpublish space") : t("Publish space")
+
+  const onClick = () => publishSpaceMutation.mutateAsync({
+    spaceId,
+    publish: !space?.isPublished
+  })
+
+  return <Button onClick={onClick}>{buttonLabel}</Button>;
+}

--- a/apps/client/src/features/space/components/settings-modal.tsx
+++ b/apps/client/src/features/space/components/settings-modal.tsx
@@ -1,7 +1,8 @@
-import {Modal, Tabs, rem, Group, ScrollArea, Text} from "@mantine/core";
+import React from "react";
+import {Modal, Tabs, rem, Group, Text} from "@mantine/core";
 import SpaceMembersList from "@/features/space/components/space-members.tsx";
 import AddSpaceMembersModal from "@/features/space/components/add-space-members-modal.tsx";
-import React, {useMemo} from "react";
+import PublishSpaceButton from "@/features/space/components/publish-space-button";
 import SpaceDetails from "@/features/space/components/space-details.tsx";
 import {useSpaceQuery} from "@/features/space/queries/space-query.ts";
 import {useSpaceAbility} from "@/features/space/permissions/use-space-ability.ts";
@@ -74,7 +75,12 @@ export default function SpaceSettingsModal({
                     {spaceAbility.can(
                       SpaceCaslAction.Manage,
                       SpaceCaslSubject.Member,
-                    ) && <AddSpaceMembersModal spaceId={space?.id}/>}
+                    ) && (
+                      <>
+                        <AddSpaceMembersModal spaceId={space?.id}/>
+                        <PublishSpaceButton spaceId={space?.id}/>
+                      </>
+                    )}
                   </Group>
 
                   <SpaceMembersList

--- a/apps/client/src/features/space/components/sidebar/space-sidebar.tsx
+++ b/apps/client/src/features/space/components/sidebar/space-sidebar.tsx
@@ -106,16 +106,21 @@ export function SpaceSidebar() {
               </div>
             </UnstyledButton>
 
-            <UnstyledButton className={classes.menu} onClick={openSettings}>
-              <div className={classes.menuItemInner}>
-                <IconSettings
-                  size={18}
-                  className={classes.menuItemIcon}
-                  stroke={2}
-                />
-                <span>{t("Space settings")}</span>
-              </div>
-            </UnstyledButton>
+            {spaceAbility.can(
+              SpaceCaslAction.Manage,
+              SpaceCaslSubject.Settings,
+            ) && (
+              <UnstyledButton className={classes.menu} onClick={openSettings}>
+                <div className={classes.menuItemInner}>
+                  <IconSettings
+                    size={18}
+                    className={classes.menuItemIcon}
+                    stroke={2}
+                  />
+                  <span>{t("Space settings")}</span>
+                </div>
+              </UnstyledButton>
+            )}
 
             {spaceAbility.can(
               SpaceCaslAction.Manage,

--- a/apps/client/src/features/space/components/sidebar/switch-space.tsx
+++ b/apps/client/src/features/space/components/sidebar/switch-space.tsx
@@ -5,6 +5,8 @@ import { getSpaceUrl } from '@/lib/config';
 import { Avatar, Button, Popover, Text } from '@mantine/core';
 import { IconChevronDown } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
+import { useAtom } from 'jotai';
+import { userAtom } from '@/features/user/atoms/current-user-atom';
 
 interface SwitchSpaceProps {
   spaceName: string;
@@ -14,6 +16,7 @@ interface SwitchSpaceProps {
 export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
   const navigate = useNavigate();
   const [opened, { close, open, toggle }] = useDisclosure(false);
+  const [user,] = useAtom(userAtom);
 
   const handleSelect = (value: string) => {
     if (value) {
@@ -21,6 +24,8 @@ export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
       close();
     }
   };
+  
+  const disabled = !user || !!user.isAnonymous
 
   return (
     <Popover
@@ -30,13 +35,14 @@ export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
       shadow="md"
       opened={opened}
       onChange={toggle}
+      disabled={disabled}
     >
       <Popover.Target>
         <Button
           variant="subtle"
           fullWidth
           justify="space-between"
-          rightSection={<IconChevronDown size={18} />}
+          rightSection={disabled? undefined : <IconChevronDown size={18} />}
           color="gray"
           onClick={open}
         >

--- a/apps/client/src/features/space/queries/space-query.ts
+++ b/apps/client/src/features/space/queries/space-query.ts
@@ -8,6 +8,7 @@ import {
 import {
   IAddSpaceMember,
   IChangeSpaceMemberRole,
+  IPublishSpace,
   IRemoveSpaceMember,
   ISpace,
   ISpaceMember,
@@ -191,6 +192,27 @@ export function useChangeSpaceMemberRoleMutation() {
       // due to pagination levels, change in cache instead
       queryClient.refetchQueries({
         queryKey: ["spaceMembers", variables.spaceId],
+      });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function usePublishMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ISpace, Error, IPublishSpace>({
+    mutationFn: ({ spaceId, publish }) => updateSpace({
+      spaceId,
+      isPublished: publish
+    }),
+    onSuccess: (data, variables) => {
+      notifications.show({ message: "Published space successfully" });
+      queryClient.invalidateQueries({
+        queryKey: ["space", variables.spaceId],
       });
     },
     onError: (error) => {

--- a/apps/client/src/features/space/types/space.types.ts
+++ b/apps/client/src/features/space/types/space.types.ts
@@ -13,6 +13,7 @@ export interface ISpace {
   slug: string;
   hostname: string;
   creatorId: string;
+  isPublished: boolean;
   createdAt: Date;
   updatedAt: Date;
   memberCount?: number;
@@ -68,10 +69,15 @@ export interface SpaceGroupInfo {
   type: "group";
 }
 
-export type ISpaceMember = { role: string } & (SpaceUserInfo | SpaceGroupInfo);
+export type ISpaceMember = { role: SpaceRole } & (SpaceUserInfo | SpaceGroupInfo);
 
 export interface IExportSpaceParams {
   spaceId: string;
   format: ExportFormat;
   includeAttachments?: boolean;
+}
+
+export interface IPublishSpace {
+  spaceId: string;
+  publish: boolean;
 }

--- a/apps/client/src/features/user/services/user-service.ts
+++ b/apps/client/src/features/user/services/user-service.ts
@@ -3,7 +3,11 @@ import { ICurrentUser, IUser } from "@/features/user/types/user.types";
 
 export async function getMyInfo(): Promise<ICurrentUser> {
   const req = await api.post<ICurrentUser>("/users/me");
-  return req.data as ICurrentUser;
+  const currentUser = req.data as ICurrentUser;
+  if (!currentUser) return currentUser
+  const user = currentUser.user
+  const isAnonymous = user.id === "anonymous"
+  return { ...currentUser, user: { ...user, isAnonymous } }
 }
 
 export async function updateUser(data: Partial<IUser>): Promise<IUser> {

--- a/apps/client/src/features/user/types/user.types.ts
+++ b/apps/client/src/features/user/types/user.types.ts
@@ -19,6 +19,7 @@ export interface IUser {
   deactivatedAt: Date;
   deletedAt: Date;
   fullPageWidth: boolean; // used for update
+  isAnonymous?: boolean;
 }
 
 export interface ICurrentUser {

--- a/apps/server/src/common/decorators/auth-user.decorator.ts
+++ b/apps/server/src/common/decorators/auth-user.decorator.ts
@@ -3,10 +3,16 @@ import {
   createParamDecorator,
   ExecutionContext,
 } from '@nestjs/common';
+import { anonymous } from '../helpers';
 
 export const AuthUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
+
+    if (request.isPublishedSpace) {
+      return anonymous;
+    }
+
     if (!request?.user?.user) {
       throw new BadRequestException('Invalid User');
     }

--- a/apps/server/src/common/guards/jwt-auth.guard.ts
+++ b/apps/server/src/common/guards/jwt-auth.guard.ts
@@ -6,24 +6,32 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 import { Reflector } from '@nestjs/core';
+import { PageRepo } from '@docmost/db/repos/page/page.repo';
+import { SpaceRepo } from '@docmost/db/repos/space/space.repo';
+import { extractPageSlugId } from '../helpers';
+import { Space } from '@docmost/db/types/entity.types';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  constructor(private reflector: Reflector) {
+  constructor(
+      private reflector: Reflector,
+      private pageRepo: PageRepo,
+      private spaceRepo: SpaceRepo
+  ) {
     super();
   }
 
-  canActivate(context: ExecutionContext) {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
+  async canActivate(context: ExecutionContext) {
+    if (this.isPublicApi(context)) return true;
 
-    if (isPublic) {
-      return true;
+    try {
+      const isJwtValid = await super.canActivate(context)
+      return isJwtValid as boolean
+    } catch (error) {
+      const isPublishedSpace = await this.isPublishedSpace(context);
+      if (isPublishedSpace) return true
+      else throw error
     }
-
-    return super.canActivate(context);
   }
 
   handleRequest(err: any, user: any, info: any) {
@@ -31,5 +39,55 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       throw err || new UnauthorizedException();
     }
     return user;
+  }
+
+  isPublicApi(context: ExecutionContext): boolean {
+    return this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+  }
+
+  async isPublishedSpace(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const referer = request?.headers?.referer;
+  
+    if (!referer) return false;
+  
+    try {
+      const { pathname } = new URL(referer);
+      const parts = pathname.split("/");
+      const sIndex = parts.indexOf("s");
+      
+      let space: Space;
+
+      if (sIndex === -1) {
+        const pIndex = parts.indexOf("p");
+        if (pIndex !== parts.length - 2) return false;
+    
+        const slug = extractPageSlugId(parts[parts.length - 1]);
+        const page = await this.pageRepo.findById(slug);
+        if (!page) return false;
+    
+        const { spaceId, workspaceId } = page;
+        space = await this.spaceRepo.findById(spaceId, workspaceId);
+      } else {
+        const spaceName = parts[sIndex + 1]
+        if (!spaceName) return false;
+
+        space = await this.spaceRepo.findBySlug(spaceName)
+      }
+
+      if (!space) return false
+
+      const { isPublished } = space
+      request.isPublishedSpace = isPublished
+
+      return isPublished
+    } catch (error) {
+      console.error('Invalid Referer URL:', referer);
+    }
+  
+    return false;
   }
 }

--- a/apps/server/src/common/helpers/types/permission.ts
+++ b/apps/server/src/common/helpers/types/permission.ts
@@ -2,6 +2,7 @@ export enum UserRole {
   OWNER = 'owner',
   ADMIN = 'admin', // can have owner permissions but cannot delete workspace
   MEMBER = 'member',
+  GUEST = 'guest',
 }
 
 export enum SpaceRole {

--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -1,5 +1,9 @@
 import * as path from 'path';
 import * as bcrypt from 'bcrypt';
+import { User } from '@docmost/db/types/entity.types';
+import { validate as isValidUUID } from 'uuid';
+import { UserRole } from './types/permission';
+import { PaginationResult } from '@docmost/db/pagination/pagination';
 
 export const envPath = path.resolve(process.cwd(), '..', '..', '.env');
 
@@ -52,4 +56,41 @@ export function extractDateFromUuid7(uuid7: string) {
   const timestamp = parseInt(highBitsHex, 16);
 
   return new Date(timestamp);
+}
+
+export function extractPageSlugId(slug: string): string {
+  if (!slug) {
+    return undefined;
+  }
+  if (isValidUUID(slug)) {
+    return slug;
+  }
+  const parts = slug.split("-");
+  return parts.length > 1 ? parts[parts.length - 1] : slug;
+}
+
+export const anonymous: User = {
+  id: 'anonymous',
+  name: 'Anonymous',
+  role: UserRole.GUEST,
+  avatarUrl: '',
+  email: '',
+  invitedById: '',
+  locale: '',
+  password: '',
+  settings: '',
+  timezone: '',
+  workspaceId: '',
+  createdAt: undefined,
+  deactivatedAt: undefined,
+  deletedAt: undefined,
+  emailVerifiedAt: undefined,
+  lastActiveAt: undefined,
+  lastLoginAt: undefined,
+  updatedAt: undefined
+}
+
+export const emptyPaginationResult: PaginationResult<any> = {
+  items: [],
+  meta: { limit: 1, page: 1, hasNextPage: false, hasPrevPage: false }
 }

--- a/apps/server/src/core/auth/auth.controller.ts
+++ b/apps/server/src/core/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import { PasswordResetDto } from './dto/password-reset.dto';
 import { VerifyUserTokenDto } from './dto/verify-user-token.dto';
 import { FastifyReply } from 'fastify';
 import { addDays } from 'date-fns';
+import { anonymous } from 'src/common/helpers';
 
 @Controller('auth')
 export class AuthController {
@@ -67,6 +68,7 @@ export class AuthController {
     @AuthUser() user: User,
     @AuthWorkspace() workspace: Workspace,
   ) {
+    if (user === anonymous) return;
     return this.authService.changePassword(dto, user.id, workspace.id);
   }
 
@@ -109,6 +111,7 @@ export class AuthController {
     @AuthUser() user: User,
     @AuthWorkspace() workspace: Workspace,
   ) {
+    if (user === anonymous) return null;
     return this.authService.getCollabToken(user.id, workspace.id);
   }
 

--- a/apps/server/src/core/casl/abilities/space-ability.factory.ts
+++ b/apps/server/src/core/casl/abilities/space-ability.factory.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import {
   AbilityBuilder,
   createMongoAbility,
@@ -13,27 +13,39 @@ import {
   SpaceCaslSubject,
 } from '../interfaces/space-ability.type';
 import { findHighestUserSpaceRole } from '@docmost/db/repos/space/utils';
+import { SpaceRepo } from '@docmost/db/repos/space/space.repo';
+import { anonymous } from 'src/common/helpers';
 
 @Injectable()
 export default class SpaceAbilityFactory {
-  constructor(private readonly spaceMemberRepo: SpaceMemberRepo) {}
-  async createForUser(user: User, spaceId: string) {
-    const userSpaceRoles = await this.spaceMemberRepo.getUserSpaceRoles(
-      user.id,
-      spaceId,
-    );
-
-    const userSpaceRole = findHighestUserSpaceRole(userSpaceRoles);
-
-    switch (userSpaceRole) {
-      case SpaceRole.ADMIN:
-        return buildSpaceAdminAbility();
-      case SpaceRole.WRITER:
-        return buildSpaceWriterAbility();
-      case SpaceRole.READER:
-        return buildSpaceReaderAbility();
-      default:
-        throw new NotFoundException('Space permissions not found');
+  constructor(
+    private readonly spaceRepo: SpaceRepo,
+    private readonly spaceMemberRepo: SpaceMemberRepo
+  ) {}
+  
+  async createForUser(user: User | undefined, spaceId: string) {
+    if (user === anonymous) {
+      const space = await this.spaceRepo.findById(spaceId)
+      if (space.isPublished) return buildSpaceReaderAbility();
+      throw new UnauthorizedException();
+    } else {
+      const userSpaceRoles = await this.spaceMemberRepo.getUserSpaceRoles(
+        user.id,
+        spaceId,
+      );
+      
+      const userSpaceRole = findHighestUserSpaceRole(userSpaceRoles);
+      
+      switch (userSpaceRole) {
+        case SpaceRole.ADMIN:
+          return buildSpaceAdminAbility();
+        case SpaceRole.WRITER:
+          return buildSpaceWriterAbility();
+        case SpaceRole.READER:
+          return buildSpaceReaderAbility();
+        default:
+          throw new NotFoundException('Space permissions not found');
+      }
     }
   }
 }

--- a/apps/server/src/core/casl/abilities/workspace-ability.factory.ts
+++ b/apps/server/src/core/casl/abilities/workspace-ability.factory.ts
@@ -24,6 +24,8 @@ export default class WorkspaceAbilityFactory {
         return buildWorkspaceAdminAbility();
       case UserRole.MEMBER:
         return buildWorkspaceMemberAbility();
+      case UserRole.GUEST:
+        return buildWorkspaceGuestAbility();
       default:
         throw new NotFoundException('Workspace permissions not found');
     }
@@ -69,5 +71,12 @@ function buildWorkspaceMemberAbility() {
   can(WorkspaceCaslAction.Read, WorkspaceCaslSubject.Group);
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Attachment);
 
+  return build();
+}
+
+function buildWorkspaceGuestAbility() {
+  const { can, build } = new AbilityBuilder<MongoAbility<IWorkspaceAbility>>(
+    createMongoAbility,
+  );
   return build();
 }

--- a/apps/server/src/core/page/page.controller.ts
+++ b/apps/server/src/core/page/page.controller.ts
@@ -27,6 +27,7 @@ import {
 import SpaceAbilityFactory from '../casl/abilities/space-ability.factory';
 import { PageRepo } from '@docmost/db/repos/page/page.repo';
 import { RecentPageDto } from './dto/recent-page.dto';
+import { anonymous, emptyPaginationResult } from 'src/common/helpers';
 
 @UseGuards(JwtAuthGuard)
 @Controller('pages')
@@ -141,6 +142,8 @@ export class PageController {
         pagination,
       );
     }
+
+    if (user === anonymous) return emptyPaginationResult;
 
     return this.pageService.getRecentPages(user.id, pagination);
   }

--- a/apps/server/src/core/search/search.controller.ts
+++ b/apps/server/src/core/search/search.controller.ts
@@ -19,6 +19,7 @@ import {
   SpaceCaslSubject,
 } from '../casl/interfaces/space-ability.type';
 import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { anonymous } from 'src/common/helpers';
 
 @UseGuards(JwtAuthGuard)
 @Controller('search')
@@ -55,6 +56,7 @@ export class SearchController {
     @AuthUser() user: User,
     @AuthWorkspace() workspace: Workspace,
   ) {
+    if (user === anonymous) return { users: [], groups: [], pages: [] };
     return this.searchService.searchSuggestions(dto, user.id, workspace.id);
   }
 }

--- a/apps/server/src/core/space/dto/create-space.dto.ts
+++ b/apps/server/src/core/space/dto/create-space.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsAlphanumeric,
+  IsBoolean,
   IsOptional,
   IsString,
   MaxLength,
@@ -22,4 +23,8 @@ export class CreateSpaceDto {
   @MaxLength(50)
   @IsAlphanumeric()
   slug: string;
+  
+  @IsOptional()
+  @IsBoolean()
+  isPublished?: boolean;
 }

--- a/apps/server/src/core/space/services/space.service.ts
+++ b/apps/server/src/core/space/services/space.service.ts
@@ -110,6 +110,7 @@ export class SpaceService {
         name: updateSpaceDto.name,
         description: updateSpaceDto.description,
         slug: updateSpaceDto.slug,
+        isPublished: updateSpaceDto.isPublished,
       },
       updateSpaceDto.spaceId,
       workspaceId,

--- a/apps/server/src/core/user/user.controller.ts
+++ b/apps/server/src/core/user/user.controller.ts
@@ -12,6 +12,7 @@ import { AuthUser } from '../../common/decorators/auth-user.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
 import { User, Workspace } from '@docmost/db/types/entity.types';
+import { anonymous } from 'src/common/helpers';
 
 @UseGuards(JwtAuthGuard)
 @Controller('users')

--- a/apps/server/src/core/workspace/controllers/workspace.controller.ts
+++ b/apps/server/src/core/workspace/controllers/workspace.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Req,
   Res,
+  UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import { WorkspaceService } from '../services/workspace.service';
@@ -33,6 +34,7 @@ import {
 import { addDays } from 'date-fns';
 import { FastifyReply } from 'fastify';
 import { EnvironmentService } from '../../../integrations/environment/environment.service';
+import { anonymous } from 'src/common/helpers';
 
 @UseGuards(JwtAuthGuard)
 @Controller('workspace')
@@ -53,7 +55,11 @@ export class WorkspaceController {
 
   @HttpCode(HttpStatus.OK)
   @Post('/info')
-  async getWorkspace(@AuthWorkspace() workspace: Workspace) {
+  async getWorkspace(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    if (user === anonymous) throw new UnauthorizedException();
     return this.workspaceService.getWorkspaceInfo(workspace.id);
   }
 

--- a/apps/server/src/database/migrations/20250216T210000-spaces-publish.ts
+++ b/apps/server/src/database/migrations/20250216T210000-spaces-publish.ts
@@ -1,0 +1,12 @@
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('spaces')
+    .addColumn('is_published', 'boolean', (col) => col.defaultTo(false).notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('spaces').dropColumn('is_published').execute();
+}

--- a/apps/server/src/database/repos/space/space.repo.ts
+++ b/apps/server/src/database/repos/space/space.repo.ts
@@ -19,7 +19,7 @@ export class SpaceRepo {
 
   async findById(
     spaceId: string,
-    workspaceId: string,
+    workspaceId?: string,
     opts?: { includeMemberCount?: boolean; trx?: KyselyTransaction },
   ): Promise<Space> {
     const db = dbOrTx(this.db, opts?.trx);
@@ -28,7 +28,10 @@ export class SpaceRepo {
       .selectFrom('spaces')
       .selectAll('spaces')
       .$if(opts?.includeMemberCount, (qb) => qb.select(this.withMemberCount))
-      .where('workspaceId', '=', workspaceId);
+    
+    if (workspaceId) {
+      query = query.where('workspaceId', '=', workspaceId);
+    }
 
     if (isValidUUID(spaceId)) {
       query = query.where('id', '=', spaceId);
@@ -40,16 +43,20 @@ export class SpaceRepo {
 
   async findBySlug(
     slug: string,
-    workspaceId: string,
+    workspaceId?: string,
     opts?: { includeMemberCount: boolean },
   ): Promise<Space> {
-    return await this.db
+    let query = this.db
       .selectFrom('spaces')
       .selectAll('spaces')
       .$if(opts?.includeMemberCount, (qb) => qb.select(this.withMemberCount))
       .where(sql`LOWER(slug)`, '=', sql`LOWER(${slug})`)
-      .where('workspaceId', '=', workspaceId)
-      .executeTakeFirst();
+    
+    if (workspaceId) {
+      query = query.where('workspaceId', '=', workspaceId);
+    }
+
+    return await query.executeTakeFirst();
   }
 
   async slugExists(

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -151,6 +151,7 @@ export interface Spaces {
   updatedAt: Generated<Timestamp>;
   visibility: Generated<string>;
   workspaceId: string;
+  isPublished: boolean;
 }
 
 export interface Users {


### PR DESCRIPTION
User interface changes:
* `Publish space` button will added next to `Add space members` button in `Space settings` -> `Members` modal.
* Anonymous users won't have user icon and dropdown menu on the upper right hand corner
* Anonymous users won't have space list dropdown or space setting menu in the side bar
* Anonymous users won't have user preference update buttons in the page kebab menu

<img width="260" alt="space-setting-screen" src="https://github.com/user-attachments/assets/05855e70-997c-41f5-a60f-b0bba2ef326d" />
<img width="260" alt="space-home-screen" src="https://github.com/user-attachments/assets/d48c08dc-f32e-4782-addb-52dce0f02fe9" />
<img width="260" alt="page-screen" src="https://github.com/user-attachments/assets/096cd217-1d02-4969-902c-8dcd44d5cf68" />

Authentication mechanism changes:
* `JwtAuthGuard` won't throw exception if the "referer" header in the request implies that the request is from a published space. Due to this change I added anonymous user handling mechanisms for a few controllers
*  When the request is from a published space, `AuthUser` decorator will return anonymous user object. This object represents a hypothetical user data that is actually not stored in DB. This user object is useful when resolving `workspaceAbility` and `spaceAbility`.

