### PR TITLE
feat: add user webhook notifications

### DIFF
--- a/apps/client/src/features/user/components/webhook-settings.tsx
+++ b/apps/client/src/features/user/components/webhook-settings.tsx
@@ -1,0 +1,334 @@
+import { useState, useEffect } from "react";
+import {
+  Group,
+  Text,
+  TextInput,
+  Select,
+  Button,
+  Switch,
+  Checkbox,
+  Stack,
+  Alert,
+  Loader,
+  Badge,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
+import { useTranslation } from "react-i18next";
+import { IconAlertCircle, IconWebhook } from "@tabler/icons-react";
+import {
+  getWebhook,
+  updateWebhook,
+  deleteWebhook,
+  testWebhook,
+} from "@/features/user/services/webhook-service";
+import {
+  IWebhook,
+  WEBHOOK_EVENTS,
+  WEBHOOK_FORMATS,
+} from "@/features/user/types/webhook.types";
+
+interface WebhookFormValues {
+  url: string;
+  format: "discord" | "slack" | "generic";
+  enabled: boolean;
+  events: string[];
+}
+
+export default function WebhookSettings() {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [webhook, setWebhook] = useState<IWebhook | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const form = useForm<WebhookFormValues>({
+    initialValues: {
+      url: "",
+      format: "discord",
+      enabled: true,
+      events: ["mention", "comment", "page_update"],
+    },
+    validate: {
+      url: (value) => {
+        if (!value) return t("URL is required");
+        try {
+          const url = new URL(value);
+          if (url.protocol !== "https:" && url.hostname !== "localhost") {
+            return t("URL must use HTTPS");
+          }
+        } catch {
+          return t("Invalid URL");
+        }
+        return null;
+      },
+      events: (value) =>
+        value.length === 0 ? t("Select at least one event") : null,
+    },
+  });
+
+  useEffect(() => {
+    loadWebhook();
+  }, []);
+
+  async function loadWebhook() {
+    try {
+      const response = await getWebhook();
+      setWebhook(response.webhook);
+      if (response.webhook) {
+        form.setValues({
+          url: "", // Don't expose URL
+          format: response.webhook.format,
+          enabled: response.webhook.enabled,
+          events: response.webhook.events,
+        });
+      }
+    } catch (err) {
+      console.error("Failed to load webhook settings", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSubmit(values: WebhookFormValues) {
+    setSaving(true);
+    try {
+      const response = await updateWebhook({
+        url: values.url,
+        format: values.format,
+        enabled: values.enabled,
+        events: values.events,
+      });
+
+      if (response.success) {
+        notifications.show({
+          message: t("Webhook settings saved"),
+          color: "green",
+        });
+        setShowForm(false);
+        loadWebhook();
+      } else {
+        notifications.show({
+          message: response.error || t("Failed to save webhook"),
+          color: "red",
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      notifications.show({
+        message: t("Failed to save webhook settings"),
+        color: "red",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleTest() {
+    setTesting(true);
+    try {
+      const response = await testWebhook();
+      if (response.success) {
+        notifications.show({
+          message: t("Test webhook sent"),
+          color: "green",
+        });
+      } else {
+        notifications.show({
+          message: response.error || t("Failed to send test webhook"),
+          color: "red",
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      notifications.show({
+        message: t("Failed to send test webhook"),
+        color: "red",
+      });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await deleteWebhook();
+      setWebhook(null);
+      form.reset();
+      notifications.show({
+        message: t("Webhook removed"),
+        color: "green",
+      });
+    } catch (err) {
+      console.error(err);
+      notifications.show({
+        message: t("Failed to remove webhook"),
+        color: "red",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Group justify="center" py="xl">
+        <Loader size="sm" />
+      </Group>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" wrap="nowrap" gap="xl">
+        <div>
+          <Group gap="xs">
+            <IconWebhook size={20} />
+            <Text size="md" fw={500}>
+              {t("Webhook Notifications")}
+            </Text>
+          </Group>
+          <Text size="sm" c="dimmed">
+            {t("Receive notifications via Discord, Slack, or custom webhooks.")}
+          </Text>
+        </div>
+      </Group>
+
+      {webhook && !showForm ? (
+        <Stack gap="sm">
+          <Group gap="xs">
+            <Badge
+              color={webhook.enabled ? "green" : "gray"}
+              variant="light"
+            >
+              {webhook.enabled ? t("Enabled") : t("Disabled")}
+            </Badge>
+            <Badge variant="light">
+              {WEBHOOK_FORMATS.find((f) => f.value === webhook.format)?.label ||
+                webhook.format}
+            </Badge>
+            {webhook.failureCount > 0 && (
+              <Badge color="red" variant="light">
+                {webhook.failureCount} {t("failures")}
+              </Badge>
+            )}
+          </Group>
+
+          <Text size="sm" c="dimmed">
+            {t("Events")}: {webhook.events.map((e) => 
+              WEBHOOK_EVENTS.find((ev) => ev.value === e)?.label || e
+            ).join(", ")}
+          </Text>
+
+          <Group gap="sm">
+            <Button
+              variant="light"
+              size="xs"
+              onClick={() => setShowForm(true)}
+            >
+              {t("Edit")}
+            </Button>
+            <Button
+              variant="light"
+              size="xs"
+              onClick={handleTest}
+              loading={testing}
+            >
+              {t("Test")}
+            </Button>
+            <Button
+              variant="light"
+              color="red"
+              size="xs"
+              onClick={handleDelete}
+              loading={deleting}
+            >
+              {t("Remove")}
+            </Button>
+          </Group>
+        </Stack>
+      ) : (
+        <form onSubmit={form.onSubmit(handleSubmit)}>
+          <Stack gap="md">
+            {webhook && (
+              <Alert
+                icon={<IconAlertCircle size={16} />}
+                color="blue"
+                variant="light"
+              >
+                {t("Enter a new URL to update your webhook configuration.")}
+              </Alert>
+            )}
+
+            <TextInput
+              label={t("Webhook URL")}
+              placeholder="https://discord.com/api/webhooks/..."
+              description={t("Must be HTTPS. For Discord, use the webhook URL from channel settings.")}
+              {...form.getInputProps("url")}
+            />
+
+            <Select
+              label={t("Format")}
+              description={t("Choose the notification format for your platform.")}
+              data={WEBHOOK_FORMATS.map((f) => ({
+                value: f.value,
+                label: t(f.label),
+              }))}
+              {...form.getInputProps("format")}
+              allowDeselect={false}
+            />
+
+            <Checkbox.Group
+              label={t("Events")}
+              description={t("Select which events trigger webhook notifications.")}
+              {...form.getInputProps("events")}
+            >
+              <Stack gap="xs" mt="xs">
+                {WEBHOOK_EVENTS.map((event) => (
+                  <Checkbox
+                    key={event.value}
+                    value={event.value}
+                    label={t(event.label)}
+                  />
+                ))}
+              </Stack>
+            </Checkbox.Group>
+
+            <Switch
+              label={t("Enabled")}
+              description={t("Toggle webhook notifications on or off.")}
+              {...form.getInputProps("enabled", { type: "checkbox" })}
+            />
+
+            <Group gap="sm">
+              <Button type="submit" loading={saving}>
+                {t("Save")}
+              </Button>
+              {webhook && (
+                <Button
+                  variant="subtle"
+                  onClick={() => setShowForm(false)}
+                >
+                  {t("Cancel")}
+                </Button>
+              )}
+            </Group>
+          </Stack>
+        </form>
+      )}
+
+      {!webhook && !showForm && (
+        <Button
+          variant="light"
+          leftSection={<IconWebhook size={16} />}
+          onClick={() => setShowForm(true)}
+        >
+          {t("Configure Webhook")}
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/apps/client/src/features/user/services/webhook-service.ts
+++ b/apps/client/src/features/user/services/webhook-service.ts
@@ -1,0 +1,29 @@
+import api from "@/lib/api-client";
+import {
+  IWebhookResponse,
+  IUpdateWebhookRequest,
+  IUpdateWebhookResponse,
+  ITestWebhookResponse,
+} from "@/features/user/types/webhook.types";
+
+export async function getWebhook(): Promise<IWebhookResponse> {
+  const req = await api.get<IWebhookResponse>("/webhooks");
+  return req as unknown as IWebhookResponse;
+}
+
+export async function updateWebhook(
+  data: IUpdateWebhookRequest
+): Promise<IUpdateWebhookResponse> {
+  const req = await api.post<IUpdateWebhookResponse>("/webhooks", data);
+  return req as unknown as IUpdateWebhookResponse;
+}
+
+export async function deleteWebhook(): Promise<{ success: boolean }> {
+  const req = await api.delete<{ success: boolean }>("/webhooks");
+  return req as unknown as { success: boolean };
+}
+
+export async function testWebhook(): Promise<ITestWebhookResponse> {
+  const req = await api.post<ITestWebhookResponse>("/webhooks/test");
+  return req as unknown as ITestWebhookResponse;
+}

--- a/apps/client/src/features/user/types/webhook.types.ts
+++ b/apps/client/src/features/user/types/webhook.types.ts
@@ -1,0 +1,49 @@
+export interface IWebhook {
+  id: string;
+  format: 'discord' | 'slack' | 'generic';
+  enabled: boolean;
+  events: string[];
+  urlConfigured: boolean;
+  lastTriggeredAt: string | null;
+  failureCount: number;
+}
+
+export interface IWebhookResponse {
+  webhook: IWebhook | null;
+}
+
+export interface IUpdateWebhookRequest {
+  url: string;
+  format?: 'discord' | 'slack' | 'generic';
+  enabled?: boolean;
+  events?: string[];
+}
+
+export interface IUpdateWebhookResponse {
+  success: boolean;
+  error?: string;
+  webhook?: {
+    id: string;
+    format: string;
+    enabled: boolean;
+    events: string[];
+  };
+}
+
+export interface ITestWebhookResponse {
+  success: boolean;
+  error?: string;
+}
+
+export const WEBHOOK_EVENTS = [
+  { value: 'mention', label: 'Mentions' },
+  { value: 'comment', label: 'Comments' },
+  { value: 'page_update', label: 'Page Updates' },
+  { value: 'page_delete', label: 'Page Deletions' },
+] as const;
+
+export const WEBHOOK_FORMATS = [
+  { value: 'discord', label: 'Discord' },
+  { value: 'slack', label: 'Slack' },
+  { value: 'generic', label: 'Generic JSON' },
+] as const;

--- a/apps/client/src/pages/settings/account/account-preferences.tsx
+++ b/apps/client/src/pages/settings/account/account-preferences.tsx
@@ -3,6 +3,7 @@ import AccountLanguage from "@/features/user/components/account-language.tsx";
 import AccountTheme from "@/features/user/components/account-theme.tsx";
 import PageWidthPref from "@/features/user/components/page-width-pref.tsx";
 import PageEditPref from "@/features/user/components/page-state-pref";
+import WebhookSettings from "@/features/user/components/webhook-settings.tsx";
 import { getAppName } from "@/lib/config.ts";
 import { Divider } from "@mantine/core";
 import { Helmet } from "react-helmet-async";
@@ -33,6 +34,10 @@ export default function AccountPreferences() {
       <Divider my={"md"} />
 
       <PageEditPref />
+
+      <Divider my={"md"} />
+
+      <WebhookSettings />
     </>
   );
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -19,6 +19,7 @@ import { TelemetryModule } from './integrations/telemetry/telemetry.module';
 import { RedisModule } from '@nestjs-labs/nestjs-ioredis';
 import { RedisConfigService } from './integrations/redis/redis-config.service';
 import { LoggerModule } from './common/logger/logger.module';
+import { WebhookModule } from './integrations/webhook/webhook.module';
 
 const enterpriseModules = [];
 try {
@@ -59,6 +60,7 @@ try {
     EventEmitterModule.forRoot(),
     SecurityModule,
     TelemetryModule,
+    WebhookModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/core/notification/notification.module.ts
+++ b/apps/server/src/core/notification/notification.module.ts
@@ -1,13 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { NotificationService } from './notification.service';
 import { NotificationController } from './notification.controller';
 import { NotificationProcessor } from './notification.processor';
 import { CommentNotificationService } from './services/comment.notification';
 import { PageNotificationService } from './services/page.notification';
 import { WsModule } from '../../ws/ws.module';
+import { WebhookModule } from '../../integrations/webhook/webhook.module';
 
 @Module({
-  imports: [WsModule],
+  imports: [WsModule, forwardRef(() => WebhookModule)],
   controllers: [NotificationController],
   providers: [
     NotificationService,

--- a/apps/server/src/core/notification/services/comment.notification.ts
+++ b/apps/server/src/core/notification/services/comment.notification.ts
@@ -13,6 +13,7 @@ import { CommentMentionEmail } from '@docmost/transactional/emails/comment-menti
 import { CommentCreateEmail } from '@docmost/transactional/emails/comment-created-email';
 import { CommentResolvedEmail } from '@docmost/transactional/emails/comment-resolved-email';
 import { getPageTitle } from '../../../common/helpers';
+import { WebhookEvent } from '../../../integrations/webhook/webhook.service';
 
 @Injectable()
 export class CommentNotificationService {
@@ -85,6 +86,17 @@ export class CommentNotificationService {
         CommentMentionEmail({ actorName: actor.name, pageTitle, pageUrl }),
       );
 
+      // Queue webhook notification
+      await this.notificationService.queueWebhook(userId, workspaceId, {
+        event: WebhookEvent.MENTION,
+        timestamp: new Date().toISOString(),
+        workspace: { id: workspaceId, name: '' },
+        page: { id: pageId, title: pageTitle, url: pageUrl, slugId: '' },
+        space: { id: spaceId, name: '', slug: '' },
+        actor: { id: actorId, name: actor.name },
+        content: `${actor.name} mentioned you in a comment`,
+      });
+
       notifiedUserIds.add(userId);
     }
 
@@ -108,6 +120,17 @@ export class CommentNotificationService {
         `${actor.name} commented on ${pageTitle}`,
         CommentCreateEmail({ actorName: actor.name, pageTitle, pageUrl }),
       );
+
+      // Queue webhook notification
+      await this.notificationService.queueWebhook(recipientId, workspaceId, {
+        event: WebhookEvent.COMMENT,
+        timestamp: new Date().toISOString(),
+        workspace: { id: workspaceId, name: '' },
+        page: { id: pageId, title: pageTitle, url: pageUrl, slugId: '' },
+        space: { id: spaceId, name: '', slug: '' },
+        actor: { id: actorId, name: actor.name },
+        content: `${actor.name} commented on ${pageTitle}`,
+      });
     }
   }
 

--- a/apps/server/src/core/notification/services/page.notification.ts
+++ b/apps/server/src/core/notification/services/page.notification.ts
@@ -7,6 +7,7 @@ import { NotificationType } from '../notification.constants';
 import { SpaceMemberRepo } from '@docmost/db/repos/space/space-member.repo';
 import { PageMentionEmail } from '@docmost/transactional/emails/page-mention-email';
 import { getPageTitle } from '../../../common/helpers';
+import { WebhookEvent } from '../../../integrations/webhook/webhook.service';
 
 @Injectable()
 export class PageNotificationService {
@@ -94,6 +95,17 @@ export class PageNotificationService {
         subject,
         PageMentionEmail({ actorName: actor.name, pageTitle, pageUrl }),
       );
+
+      // Queue webhook notification
+      await this.notificationService.queueWebhook(userId, workspaceId, {
+        event: WebhookEvent.MENTION,
+        timestamp: new Date().toISOString(),
+        workspace: { id: workspaceId, name: '' },
+        page: { id: pageId, title: pageTitle, url: pageUrl, slugId: '' },
+        space: { id: spaceId, name: '', slug: '' },
+        actor: { id: actorId, name: actor.name },
+        content: `${actor.name} mentioned you in ${pageTitle}`,
+      });
     }
   }
 

--- a/apps/server/src/database/migrations/20260224T000000-user-webhooks.ts
+++ b/apps/server/src/database/migrations/20260224T000000-user-webhooks.ts
@@ -1,0 +1,46 @@
+import { type Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('user_webhooks')
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(sql`gen_uuid_v7()`),
+    )
+    .addColumn('user_id', 'uuid', (col) =>
+      col.references('users.id').onDelete('cascade').notNull(),
+    )
+    .addColumn('workspace_id', 'uuid', (col) =>
+      col.references('workspaces.id').onDelete('cascade').notNull(),
+    )
+    .addColumn('url', 'text', (col) => col.notNull())
+    .addColumn('format', 'varchar(20)', (col) =>
+      col.notNull().defaultTo('discord'),
+    )
+    .addColumn('enabled', 'boolean', (col) => col.notNull().defaultTo(true))
+    .addColumn('events', 'jsonb', (col) =>
+      col.notNull().defaultTo(sql`'["mention", "comment", "page_update"]'::jsonb`),
+    )
+    .addColumn('last_triggered_at', 'timestamptz')
+    .addColumn('failure_count', 'integer', (col) => col.notNull().defaultTo(0))
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn('updated_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addUniqueConstraint('uq_user_webhooks_user_workspace', [
+      'user_id',
+      'workspace_id',
+    ])
+    .execute();
+
+  await db.schema
+    .createIndex('idx_user_webhooks_user_id')
+    .on('user_webhooks')
+    .column('user_id')
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('user_webhooks').execute();
+}

--- a/apps/server/src/database/repos/webhook/webhook.repo.ts
+++ b/apps/server/src/database/repos/webhook/webhook.repo.ts
@@ -1,0 +1,185 @@
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { KyselyDB } from '@docmost/db/types/kysely.types';
+
+export interface UserWebhook {
+  id: string;
+  userId: string;
+  workspaceId: string;
+  url: string;
+  format: 'discord' | 'slack' | 'generic';
+  enabled: boolean;
+  events: string[];
+  lastTriggeredAt: Date | null;
+  failureCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface InsertableUserWebhook {
+  userId: string;
+  workspaceId: string;
+  url: string;
+  format?: 'discord' | 'slack' | 'generic';
+  enabled?: boolean;
+  events?: string[];
+}
+
+export interface UpdatableUserWebhook {
+  url?: string;
+  format?: 'discord' | 'slack' | 'generic';
+  enabled?: boolean;
+  events?: string[];
+}
+
+// Note: After running the migration, regenerate types with kysely-codegen
+// The 'user_webhooks' table will be available as 'userWebhooks' in the DB type
+
+@Injectable()
+export class WebhookRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  // Use type assertion since kysely-codegen hasn't been run yet
+  private get webhooksTable() {
+    return this.db.selectFrom('user_webhooks' as any);
+  }
+
+  async findByUserAndWorkspace(
+    userId: string,
+    workspaceId: string,
+  ): Promise<UserWebhook | undefined> {
+    const result = await (this.db as any)
+      .selectFrom('user_webhooks')
+      .selectAll()
+      .where('user_id', '=', userId)
+      .where('workspace_id', '=', workspaceId)
+      .executeTakeFirst();
+
+    return result ? this.mapToUserWebhook(result) : undefined;
+  }
+
+  async findById(webhookId: string): Promise<UserWebhook | undefined> {
+    const result = await (this.db as any)
+      .selectFrom('user_webhooks')
+      .selectAll()
+      .where('id', '=', webhookId)
+      .executeTakeFirst();
+
+    return result ? this.mapToUserWebhook(result) : undefined;
+  }
+
+  async upsert(data: InsertableUserWebhook): Promise<UserWebhook> {
+    const existing = await this.findByUserAndWorkspace(
+      data.userId,
+      data.workspaceId,
+    );
+
+    if (existing) {
+      const result = await (this.db as any)
+        .updateTable('user_webhooks')
+        .set({
+          url: data.url,
+          format: data.format,
+          enabled: data.enabled,
+          events: JSON.stringify(data.events),
+          updated_at: new Date(),
+        })
+        .where('id', '=', existing.id)
+        .returningAll()
+        .executeTakeFirst();
+      return this.mapToUserWebhook(result);
+    }
+
+    const result = await (this.db as any)
+      .insertInto('user_webhooks')
+      .values({
+        user_id: data.userId,
+        workspace_id: data.workspaceId,
+        url: data.url,
+        format: data.format ?? 'discord',
+        enabled: data.enabled ?? true,
+        events: JSON.stringify(data.events ?? ['mention', 'comment', 'page_update']),
+      })
+      .returningAll()
+      .executeTakeFirst();
+    return this.mapToUserWebhook(result);
+  }
+
+  async update(
+    webhookId: string,
+    data: UpdatableUserWebhook,
+  ): Promise<UserWebhook | undefined> {
+    const updateData: Record<string, unknown> = { updated_at: new Date() };
+    if (data.url !== undefined) updateData.url = data.url;
+    if (data.format !== undefined) updateData.format = data.format;
+    if (data.enabled !== undefined) updateData.enabled = data.enabled;
+    if (data.events !== undefined) updateData.events = JSON.stringify(data.events);
+
+    const result = await (this.db as any)
+      .updateTable('user_webhooks')
+      .set(updateData)
+      .where('id', '=', webhookId)
+      .returningAll()
+      .executeTakeFirst();
+
+    return result ? this.mapToUserWebhook(result) : undefined;
+  }
+
+  async delete(userId: string, workspaceId: string): Promise<void> {
+    await (this.db as any)
+      .deleteFrom('user_webhooks')
+      .where('user_id', '=', userId)
+      .where('workspace_id', '=', workspaceId)
+      .execute();
+  }
+
+  async incrementFailureCount(webhookId: string): Promise<void> {
+    await (this.db as any)
+      .updateTable('user_webhooks')
+      .set((eb: any) => ({
+        failure_count: eb('failure_count', '+', 1),
+        updated_at: new Date(),
+      }))
+      .where('id', '=', webhookId)
+      .execute();
+  }
+
+  async resetFailureCount(webhookId: string): Promise<void> {
+    await (this.db as any)
+      .updateTable('user_webhooks')
+      .set({
+        failure_count: 0,
+        last_triggered_at: new Date(),
+        updated_at: new Date(),
+      })
+      .where('id', '=', webhookId)
+      .execute();
+  }
+
+  async disableWebhook(webhookId: string): Promise<void> {
+    await (this.db as any)
+      .updateTable('user_webhooks')
+      .set({
+        enabled: false,
+        updated_at: new Date(),
+      })
+      .where('id', '=', webhookId)
+      .execute();
+  }
+
+  private mapToUserWebhook(row: any): UserWebhook {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      workspaceId: row.workspace_id,
+      url: row.url,
+      format: row.format,
+      enabled: row.enabled,
+      events: typeof row.events === 'string' ? JSON.parse(row.events) : row.events,
+      lastTriggeredAt: row.last_triggered_at,
+      failureCount: row.failure_count,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/apps/server/src/integrations/webhook/webhook.controller.ts
+++ b/apps/server/src/integrations/webhook/webhook.controller.ts
@@ -1,0 +1,151 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { WebhookService } from './webhook.service';
+import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import {
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsArray,
+} from 'class-validator';
+
+class UpdateWebhookDto {
+  @IsUrl({ protocols: ['https'], require_protocol: true })
+  @IsString()
+  url: string;
+
+  @IsOptional()
+  @IsEnum(['discord', 'slack', 'generic'])
+  format?: 'discord' | 'slack' | 'generic';
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  events?: string[];
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('webhooks')
+export class WebhookController {
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @HttpCode(HttpStatus.OK)
+  @Get()
+  async getWebhook(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    const webhook = await this.webhookService.getUserWebhook(
+      user.id,
+      workspace.id,
+    );
+    if (!webhook) {
+      return { webhook: null };
+    }
+    // Don't expose the full URL for security, just indicate it's configured
+    return {
+      webhook: {
+        id: webhook.id,
+        format: webhook.format,
+        enabled: webhook.enabled,
+        events: webhook.events,
+        urlConfigured: true,
+        lastTriggeredAt: webhook.lastTriggeredAt,
+        failureCount: webhook.failureCount,
+      },
+    };
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post()
+  async updateWebhook(
+    @Body() dto: UpdateWebhookDto,
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    // Validate URL is HTTPS (except localhost for development)
+    const url = new URL(dto.url);
+    if (url.protocol !== 'https:' && url.hostname !== 'localhost') {
+      return {
+        success: false,
+        error: 'Webhook URL must use HTTPS',
+      };
+    }
+
+    // Block internal network URLs (SSRF protection)
+    const hostname = url.hostname;
+    if (
+      hostname.startsWith('10.') ||
+      hostname.startsWith('192.168.') ||
+      hostname.startsWith('172.16.') ||
+      hostname.startsWith('172.17.') ||
+      hostname.startsWith('172.18.') ||
+      hostname.startsWith('172.19.') ||
+      hostname.startsWith('172.2') ||
+      hostname.startsWith('172.30.') ||
+      hostname.startsWith('172.31.') ||
+      (hostname === '127.0.0.1' && process.env.NODE_ENV === 'production')
+    ) {
+      return {
+        success: false,
+        error: 'Internal network URLs are not allowed',
+      };
+    }
+
+    const webhook = await this.webhookService.createOrUpdate(
+      user.id,
+      workspace.id,
+      dto,
+    );
+
+    return {
+      success: true,
+      webhook: {
+        id: webhook.id,
+        format: webhook.format,
+        enabled: webhook.enabled,
+        events: webhook.events,
+      },
+    };
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Delete()
+  async deleteWebhook(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    await this.webhookService.delete(user.id, workspace.id);
+    return { success: true };
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('test')
+  async testWebhook(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    const result = await this.webhookService.sendTestWebhook(
+      user.id,
+      workspace.id,
+    );
+    return result;
+  }
+}

--- a/apps/server/src/integrations/webhook/webhook.module.ts
+++ b/apps/server/src/integrations/webhook/webhook.module.ts
@@ -1,0 +1,28 @@
+import { Module, Global } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { WebhookService } from './webhook.service';
+import { WebhookProcessor } from './webhook.processor';
+import { WebhookController } from './webhook.controller';
+import { WebhookRepo } from '../../database/repos/webhook/webhook.repo';
+
+@Global()
+@Module({
+  imports: [
+    BullModule.registerQueue({
+      name: 'webhook-queue',
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 5000,
+        },
+        removeOnComplete: true,
+        removeOnFail: 100,
+      },
+    }),
+  ],
+  controllers: [WebhookController],
+  providers: [WebhookService, WebhookProcessor, WebhookRepo],
+  exports: [WebhookService],
+})
+export class WebhookModule {}

--- a/apps/server/src/integrations/webhook/webhook.processor.ts
+++ b/apps/server/src/integrations/webhook/webhook.processor.ts
@@ -1,0 +1,195 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { WebhookRepo } from '../../database/repos/webhook/webhook.repo';
+import {
+  WebhookDeliveryJob,
+  WebhookEvent,
+  WebhookPayload,
+} from './webhook.service';
+
+const MAX_FAILURE_COUNT = 10;
+const WEBHOOK_TIMEOUT_MS = 10000;
+
+interface DiscordEmbed {
+  embeds: Array<{
+    title: string;
+    description: string;
+    url?: string;
+    color: number;
+    author?: {
+      name: string;
+      icon_url?: string;
+    };
+    fields?: Array<{
+      name: string;
+      value: string;
+      inline?: boolean;
+    }>;
+    timestamp?: string;
+  }>;
+}
+
+@Processor('webhook-queue')
+export class WebhookProcessor extends WorkerHost {
+  private readonly logger = new Logger(WebhookProcessor.name);
+
+  constructor(private readonly webhookRepo: WebhookRepo) {
+    super();
+  }
+
+  async process(job: Job<WebhookDeliveryJob>): Promise<void> {
+    const { webhookId, url, format, payload } = job.data;
+
+    try {
+      const formattedPayload = this.formatPayload(format, payload);
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        WEBHOOK_TIMEOUT_MS,
+      );
+
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'Docmost-Webhook/1.0',
+          },
+          body: JSON.stringify(formattedPayload),
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        // Success - reset failure count
+        await this.webhookRepo.resetFailureCount(webhookId);
+        this.logger.log(`Webhook delivered successfully to ${url}`);
+      } catch (fetchError) {
+        clearTimeout(timeoutId);
+        throw fetchError;
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      this.logger.error(`Webhook delivery failed for ${webhookId}: ${message}`);
+
+      // Increment failure count
+      await this.webhookRepo.incrementFailureCount(webhookId);
+
+      // Check if we should disable the webhook
+      const webhook = await this.webhookRepo.findById(webhookId);
+      if (webhook && webhook.failureCount >= MAX_FAILURE_COUNT) {
+        await this.webhookRepo.disableWebhook(webhookId);
+        this.logger.warn(
+          `Webhook ${webhookId} disabled after ${MAX_FAILURE_COUNT} failures`,
+        );
+      }
+
+      // Re-throw to let BullMQ handle retries
+      throw err;
+    }
+  }
+
+  private formatPayload(
+    format: 'discord' | 'slack' | 'generic',
+    payload: WebhookPayload,
+  ): DiscordEmbed | WebhookPayload {
+    switch (format) {
+      case 'discord':
+        return this.formatDiscordPayload(payload);
+      case 'slack':
+        return this.formatSlackPayload(payload);
+      default:
+        return payload;
+    }
+  }
+
+  private formatDiscordPayload(payload: WebhookPayload): DiscordEmbed {
+    return {
+      embeds: [
+        {
+          title: this.getEventTitle(payload.event),
+          description:
+            payload.content || `Page: **${payload.page.title}**`,
+          url: payload.page.url,
+          color: this.getEventColor(payload.event),
+          author: {
+            name: payload.actor.name,
+            icon_url: payload.actor.avatarUrl,
+          },
+          fields: [
+            {
+              name: 'Space',
+              value: payload.space.name,
+              inline: true,
+            },
+            {
+              name: 'Page',
+              value: payload.page.title,
+              inline: true,
+            },
+          ],
+          timestamp: payload.timestamp,
+        },
+      ],
+    };
+  }
+
+  private formatSlackPayload(payload: WebhookPayload): object {
+    return {
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${this.getEventTitle(payload.event)}*\n${payload.content || `Page: <${payload.page.url}|${payload.page.title}>`}`,
+          },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `*Space:* ${payload.space.name} | *Page:* ${payload.page.title} | *By:* ${payload.actor.name}`,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  private getEventTitle(event: WebhookEvent): string {
+    switch (event) {
+      case WebhookEvent.MENTION:
+        return '📢 You were mentioned';
+      case WebhookEvent.COMMENT:
+        return '💬 New comment';
+      case WebhookEvent.PAGE_UPDATE:
+        return '📝 Page updated';
+      case WebhookEvent.PAGE_DELETE:
+        return '🗑️ Page deleted';
+      default:
+        return '🔔 Notification';
+    }
+  }
+
+  private getEventColor(event: WebhookEvent): number {
+    switch (event) {
+      case WebhookEvent.MENTION:
+        return 0x5865f2; // Discord blurple
+      case WebhookEvent.COMMENT:
+        return 0x57f287; // Green
+      case WebhookEvent.PAGE_UPDATE:
+        return 0xfee75c; // Yellow
+      case WebhookEvent.PAGE_DELETE:
+        return 0xed4245; // Red
+      default:
+        return 0x99aab5; // Gray
+    }
+  }
+}

--- a/apps/server/src/integrations/webhook/webhook.service.ts
+++ b/apps/server/src/integrations/webhook/webhook.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import {
+  WebhookRepo,
+  UserWebhook,
+} from '../../database/repos/webhook/webhook.repo';
+
+export enum WebhookEvent {
+  MENTION = 'mention',
+  COMMENT = 'comment',
+  PAGE_UPDATE = 'page_update',
+  PAGE_DELETE = 'page_delete',
+}
+
+export interface WebhookPayload {
+  event: WebhookEvent;
+  timestamp: string;
+  workspace: { id: string; name: string };
+  page: { id: string; title: string; url: string; slugId: string };
+  space: { id: string; name: string; slug: string };
+  actor: { id: string; name: string; avatarUrl?: string };
+  content?: string;
+}
+
+export interface WebhookDeliveryJob {
+  webhookId: string;
+  url: string;
+  format: 'discord' | 'slack' | 'generic';
+  payload: WebhookPayload;
+}
+
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
+  constructor(
+    private readonly webhookRepo: WebhookRepo,
+    @InjectQueue('webhook-queue') private webhookQueue: Queue,
+  ) {}
+
+  async getUserWebhook(
+    userId: string,
+    workspaceId: string,
+  ): Promise<UserWebhook | undefined> {
+    return this.webhookRepo.findByUserAndWorkspace(userId, workspaceId);
+  }
+
+  async createOrUpdate(
+    userId: string,
+    workspaceId: string,
+    dto: {
+      url: string;
+      format?: 'discord' | 'slack' | 'generic';
+      enabled?: boolean;
+      events?: string[];
+    },
+  ): Promise<UserWebhook> {
+    return this.webhookRepo.upsert({
+      userId,
+      workspaceId,
+      ...dto,
+    });
+  }
+
+  async delete(userId: string, workspaceId: string): Promise<void> {
+    return this.webhookRepo.delete(userId, workspaceId);
+  }
+
+  async queueDelivery(
+    userId: string,
+    workspaceId: string,
+    payload: WebhookPayload,
+  ): Promise<void> {
+    try {
+      const webhook = await this.getUserWebhook(userId, workspaceId);
+      if (!webhook?.enabled) return;
+      if (!webhook.events.includes(payload.event)) return;
+
+      await this.webhookQueue.add('deliver', {
+        webhookId: webhook.id,
+        url: webhook.url,
+        format: webhook.format,
+        payload,
+      } as WebhookDeliveryJob);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      this.logger.error(
+        `Failed to queue webhook for user ${userId}: ${message}`,
+      );
+    }
+  }
+
+  async sendTestWebhook(
+    userId: string,
+    workspaceId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const webhook = await this.getUserWebhook(userId, workspaceId);
+    if (!webhook) {
+      return { success: false, error: 'No webhook configured' };
+    }
+
+    const testPayload: WebhookPayload = {
+      event: WebhookEvent.MENTION,
+      timestamp: new Date().toISOString(),
+      workspace: { id: workspaceId, name: 'Test Workspace' },
+      page: {
+        id: 'test-page-id',
+        title: 'Test Page',
+        url: '/test',
+        slugId: 'test',
+      },
+      space: { id: 'test-space-id', name: 'Test Space', slug: 'test' },
+      actor: { id: userId, name: 'Test User' },
+      content: 'This is a test webhook notification from Docmost.',
+    };
+
+    await this.webhookQueue.add(
+      'deliver',
+      {
+        webhookId: webhook.id,
+        url: webhook.url,
+        format: webhook.format,
+        payload: testPayload,
+      } as WebhookDeliveryJob,
+      { priority: 1 }, // High priority for test
+    );
+
+    return { success: true };
+  }
+}


### PR DESCRIPTION
## Summary

Adds per-user configurable webhook notifications for Docmost. Users can configure webhooks to receive notifications in Discord, Slack, or generic JSON format.

## Features

- **Database**: New `user_webhooks` table with user+workspace uniqueness
- **API Endpoints**:
  - `GET /webhooks` - Get current webhook configuration
  - `POST /webhooks` - Create/update webhook settings
  - `DELETE /webhooks` - Remove webhook
  - `POST /webhooks/test` - Send test notification
- **Frontend**: Webhook settings in Account Preferences
- **Webhook Formats**: Discord embeds, Slack blocks, generic JSON
- **Reliability**: 
  - 3 retry attempts with exponential backoff
  - Auto-disable after 10 consecutive failures
  - 10 second timeout
- **Security**:
  - HTTPS-only URLs (except localhost in dev)
  - SSRF protection (blocks internal network URLs)

## Testing Checklist

- [ ] Run migration
- [ ] Run `kysely-codegen` to update DB types
- [ ] Configure Discord webhook in Settings → Preferences
- [ ] Trigger a mention/comment notification
- [ ] Verify Discord receives the webhook

## Event Types

- `mention` - User mentioned in page/comment
- `comment` - Comment on watched page
- `page_update` - Watched page edited
- `page_delete` - Watched page deleted